### PR TITLE
Add script and config references in include.sh

### DIFF
--- a/include.sh
+++ b/include.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+AC_ADD_SCRIPT("${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+AC_ADD_CONFIGURATION_FILE("${CMAKE_CURRENT_SOURCE_DIR}/conf/my_custom.conf.dist")


### PR DESCRIPTION
## Summary
- integrate src scripts into build with AC_ADD_SCRIPT
- register my_custom.conf.dist as a configuration file

## Testing
- `bash ./apps/ci/ci-codestyle.sh` *(fails: Remove whitespace at the end of the lines above)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6790e1788323803683d7dbec955f