### PR TITLE
Add chrono literals for Polydeuces and Kayken

### DIFF
--- a/src/boss_polydeuces.cpp
+++ b/src/boss_polydeuces.cpp
@@ -5,7 +5,9 @@
 
 #include "kaykens_reminiszenz.h"
 #include "Log.h"
+#include <chrono>
 
+using namespace std::chrono_literals;
 
 struct PolydeucesWaypoint
 {

--- a/src/npc_kayken.cpp
+++ b/src/npc_kayken.cpp
@@ -10,6 +10,9 @@
 #include "ObjectMgr.h"
 #include "QuestDef.h"
 #include "TaskScheduler.h"
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 // Kayken uses database-driven gossip menus (60000-60007)
 // Only Menu 60007 requires script intervention for teleportation


### PR DESCRIPTION
## Summary
- include `<chrono>` in Polydeuces boss and Kayken NPC scripts
- enable chrono duration literals for event scheduling

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac67aa6d108323a0fe7afaa4c65040