### PR TITLE
Guard debug strings in boss and NPC scripts

### DIFF
--- a/src/boss_polydeuces.cpp
+++ b/src/boss_polydeuces.cpp
@@ -6,6 +6,13 @@
 #include "kaykens_reminiszenz.h"
 #include "Log.h"
 
+#ifdef DEBUG
+#define KR_DEBUG_SAY(text) me->Say(text, LANG_UNIVERSAL)
+#define KR_DEBUG_YELL(text) me->Yell(text, LANG_UNIVERSAL)
+#else
+#define KR_DEBUG_SAY(text)
+#define KR_DEBUG_YELL(text)
+#endif
 
 struct PolydeucesWaypoint
 {
@@ -22,7 +29,7 @@ public:
         boss_polydeucesAI(Creature* creature) : ScriptedAI(creature)
         {
             // ULTIMATE DEBUG - CONSTRUCTOR CALLED
-            me->Say("CONSTRUCTOR: ### NEUE KR MODULE VERSION 2.0 - POLYDEUCES LOADED ###", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("CONSTRUCTOR: ### NEUE KR MODULE VERSION 2.0 - POLYDEUCES LOADED ###");
             
             _instance = me->GetInstanceScript();
             // Store original spawn position for Dione
@@ -33,7 +40,7 @@ public:
         void Initialize()
         {
             // ULTIMATE DEBUG - UNIQUE STRING to identify OUR script
-            me->Yell("### NEUE KR MODULE VERSION 2.0 GELADEN ###", LANG_UNIVERSAL);
+            KR_DEBUG_YELL("### NEUE KR MODULE VERSION 2.0 GELADEN ###");
             
             _phase = PHASE_PREPARATION;
             _isFlying = false;
@@ -79,7 +86,7 @@ public:
         void Reset() override
         {
             // ULTIMATE DEBUG - This WILL be called when boss resets
-            me->Say("ULTIMATE DEBUG: Polydeuces Reset() called!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("ULTIMATE DEBUG: Polydeuces Reset() called!");
             events.Reset();
             
             // Onyxia-style: Explicitly disable flight capabilities on reset
@@ -94,12 +101,12 @@ public:
         void JustEngagedWith(Unit* who) override
         {
             // IMMEDIATE DEBUG - Test if our script runs at all
-            me->Say("DEBUG: POLYDEUCES SCRIPT IS RUNNING! Combat started!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: POLYDEUCES SCRIPT IS RUNNING! Combat started!");
             
             if (_phase == PHASE_PREPARATION)
             {
                 // Still in preparation - shouldn't happen but handle gracefully
-                me->Say("DEBUG: Still in preparation phase!", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: Still in preparation phase!");
                 return;
             }
             
@@ -176,29 +183,29 @@ public:
         void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*damagetype*/, SpellSchoolMask /*damageSchoolMask*/) override
         {
             // DEBUG: Show HP percentage
-            me->Say("DEBUG: HP is " + std::to_string(me->GetHealthPct()) + "%", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: HP is " + std::to_string(me->GetHealthPct()) + "%");
             
             // Only trigger flight phases during ground combat (PHASE_ONE)
             if (_phase != PHASE_ONE || _isFlying)
             {
-                me->Say("DEBUG: Wrong phase or already flying - phase=" + std::to_string(_phase) + " flying=" + std::to_string(_isFlying), LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: Wrong phase or already flying - phase=" + std::to_string(_phase) + " flying=" + std::to_string(_isFlying));
                 return;
             }
                 
             // WOTLK-Style: Exactly two flight phases at 66% and 33%
             if (me->HealthBelowPctDamaged(66, damage) && !_firstFlightDone)
             {
-                me->Say("DEBUG: Triggering first flight phase at 66%!", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: Triggering first flight phase at 66%!");
                 StartFlightPhase();
             }
             else if (me->HealthBelowPctDamaged(33, damage) && _firstFlightDone && !_secondFlightDone)
             {
-                me->Say("DEBUG: Triggering second and FINAL flight phase at 33%!", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: Triggering second and FINAL flight phase at 33%!");
                 StartFlightPhase();
             }
             else if (me->HealthBelowPctDamaged(33, damage) && _secondFlightDone)
             {
-                me->Say("DEBUG: No more flight phases - staying on ground!", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: No more flight phases - staying on ground!");
             }
         }
 
@@ -306,7 +313,7 @@ public:
                         break;
                     case EVENT_LANDING_FALLBACK:
                         // Fallback: Force landing completion if MovementInform didn't trigger
-                        me->Say("DEBUG: Landing fallback triggered!", LANG_UNIVERSAL);
+                        KR_DEBUG_SAY("DEBUG: Landing fallback triggered!");
                         CompleteLanding();
                         break;
                 }
@@ -396,7 +403,7 @@ public:
             _isFlying = true;
             
             // Start air phase sequence
-            me->Say("DEBUG: Starting air phase with Onyxia-style takeoff!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: Starting air phase with Onyxia-style takeoff!");
             OnAirPhaseReached();
         }
         
@@ -406,7 +413,7 @@ public:
             events.CancelEvent(EVENT_SPAWN_DIONE);
             
             // Start proper air phase sequence
-            me->Say("DEBUG: Air phase reached - starting events!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: Air phase reached - starting events!");
             me->Yell("Jetzt werdet ihr die wahre Macht der Drachen spüren!", LANG_UNIVERSAL);
             
             // Immediate Dione spawn
@@ -435,7 +442,7 @@ public:
             events.CancelEvent(EVENT_UNROOT);
             
             // Simplified flight phase start
-            me->Say("DEBUG: Flight phase starting!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: Flight phase starting!");
             me->AttackStop();
             me->SetReactState(REACT_PASSIVE);
             me->GetMotionMaster()->Clear();
@@ -542,7 +549,7 @@ public:
                 return;
             }
             
-            me->Say("DEBUG: Waypoint " + std::to_string(waypointId) + " reached! Starting bombardment!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: Waypoint " + std::to_string(waypointId) + " reached! Starting bombardment!");
             
             // Start bombardment sequence when reaching waypoint
             if (_isFlying)
@@ -553,7 +560,7 @@ public:
                 
                 // Start first fireball immediately
                 events.ScheduleEvent(EVENT_FIREBALL_BOMBARDMENT, 500);
-                me->Say("DEBUG: Fireball bombardment started - " + std::to_string(_totalFireballs) + " fireballs!", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: Fireball bombardment started - " + std::to_string(_totalFireballs) + " fireballs!");
             }
         }
 
@@ -580,7 +587,7 @@ public:
                 _dioneSpawned = true;
                 
                 // Debug output
-                me->Say("DEBUG: Dione spawned successfully!", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: Dione spawned successfully!");
                 
                 // Initialize Dione properly for combat
                 dione->SetReactState(REACT_AGGRESSIVE);
@@ -590,11 +597,11 @@ public:
                 if (Unit* target = dione->SelectNearestTarget(100.0f))
                 {
                     dione->AI()->AttackStart(target);
-                    me->Say("DEBUG: Dione attacking target!", LANG_UNIVERSAL);
+                    KR_DEBUG_SAY("DEBUG: Dione attacking target!");
                 }
                 else
                 {
-                    me->Say("DEBUG: Dione found no targets!", LANG_UNIVERSAL);
+                    KR_DEBUG_SAY("DEBUG: Dione found no targets!");
                 }
                 
                 // Start death checking after spawn is complete
@@ -607,7 +614,7 @@ public:
                 _currentDioneGUID.Clear();
                 
                 // Debug output
-                me->Say("DEBUG: Dione spawn failed! Retrying in 5 seconds...", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: Dione spawn failed! Retrying in 5 seconds...");
                 events.ScheduleEvent(EVENT_SPAWN_DIONE, 5s); // Retry spawn
             }
         }
@@ -618,7 +625,7 @@ public:
             if (!_dioneSpawned || !_isFlying || _currentDioneGUID.IsEmpty())
             {
                 // Debug: Why we stopped checking
-                me->Say("DEBUG: Stopped Dione death check", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: Stopped Dione death check");
                 return;
             }
             
@@ -634,13 +641,13 @@ public:
                 else
                 {
                     // Dione died - debug info
-                    me->Say("DEBUG: Dione died! Initiating landing...", LANG_UNIVERSAL);
+                        KR_DEBUG_SAY("DEBUG: Dione died! Initiating landing...");
                 }
             }
             else
             {
                 // Dione despawned - debug info  
-                me->Say("DEBUG: Dione despawned! Initiating landing...", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: Dione despawned! Initiating landing...");
             }
             
             // Dione is dead or despawned
@@ -668,7 +675,7 @@ public:
             me->Yell(PolydeucesTexts::SAY_LAND, LANG_UNIVERSAL);
             me->SendMeleeAttackStop(me->GetVictim());
             
-            me->Say("DEBUG: Initiating proper landing sequence!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: Initiating proper landing sequence!");
             
             // Use proper MoveLand to home position like Onyxia
             Position homePos = me->GetHomePosition();
@@ -687,7 +694,7 @@ public:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random))
             {
                 CastScaledSpell(target, SPELL_FIREBALL);
-                me->Say("DEBUG: Fireball " + std::to_string(_totalFireballs - _fireballsRemaining + 1) + "/" + std::to_string(_totalFireballs) + " fired!", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: Fireball " + std::to_string(_totalFireballs - _fireballsRemaining + 1) + "/" + std::to_string(_totalFireballs) + " fired!");
                 _fireballsRemaining--;
                 
                 if (_fireballsRemaining > 0)
@@ -698,7 +705,7 @@ public:
                 else
                 {
                     // Bombardment finished - move to next waypoint
-                    me->Say("DEBUG: Bombardment completed! Moving to next waypoint...", LANG_UNIVERSAL);
+                    KR_DEBUG_SAY("DEBUG: Bombardment completed! Moving to next waypoint...");
                     events.ScheduleEvent(EVENT_NEXT_WAYPOINT, 2000); // Short delay before moving
                 }
             }
@@ -718,7 +725,7 @@ public:
             // Cancel any pending landing fallback
             events.CancelEvent(EVENT_LANDING_FALLBACK);
             
-            me->Say("DEBUG: Landing completed with proper MoveLand sequence!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: Landing completed with proper MoveLand sequence!");
             
             // No manual teleportation needed - MoveLand already positioned us correctly
             // Just disable flight capabilities like Onyxia
@@ -740,23 +747,23 @@ public:
             if (Unit* target = me->SelectVictim())
             {
                 AttackStart(target);
-                me->Say("DEBUG: Resuming combat with target!", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: Resuming combat with target!");
             }
             
             // Track flight phases with proper progression
             if (!_firstFlightDone)
             {
                 _firstFlightDone = true;
-                me->Say("DEBUG: First flight phase completed! Next phase at 33% HP.", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: First flight phase completed! Next phase at 33% HP.");
             }
             else if (!_secondFlightDone)
             {
                 _secondFlightDone = true;
-                me->Say("DEBUG: Second and FINAL flight phase completed! No more flying!", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: Second and FINAL flight phase completed! No more flying!");
             }
             else
             {
-                me->Say("DEBUG: ERROR - Unexpected flight phase completion!", LANG_UNIVERSAL);
+                KR_DEBUG_SAY("DEBUG: ERROR - Unexpected flight phase completion!");
             }
             
             // Reset Dione variables

--- a/src/npc_hexenmeister.cpp
+++ b/src/npc_hexenmeister.cpp
@@ -5,6 +5,12 @@
 
 #include "kaykens_reminiszenz.h"
 
+#ifdef DEBUG
+#define KR_DEBUG_SAY(text) me->Say(text, LANG_UNIVERSAL)
+#else
+#define KR_DEBUG_SAY(text)
+#endif
+
 class npc_hexenmeister : public CreatureScript
 {
 public:
@@ -20,13 +26,13 @@ public:
         void Reset() override
         {
             // ULTIMATE DEBUG - Test if Hexenmeister script runs
-            me->Say("ULTIMATE DEBUG: Hexenmeister Reset() called!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("ULTIMATE DEBUG: Hexenmeister Reset() called!");
             
             events.Reset();
             
             // Clear any existing emotes before setting new ones
             me->HandleEmoteCommand(EMOTE_ONESHOT_NONE);
-            me->Say("DEBUG: Emotes cleared on Reset!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: Emotes cleared on Reset!");
             
             CastDarkEnergyOnPolydeuces();
             // Start continuous dark energy casting
@@ -36,7 +42,7 @@ public:
         void JustEngagedWith(Unit* /*who*/) override
         {
             // ULTIMATE DEBUG - Test if combat works
-            me->Say("ULTIMATE DEBUG: Hexenmeister Combat started!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("ULTIMATE DEBUG: Hexenmeister Combat started!");
             
             // Random modern C++ string yell
             uint8 randomYell = urand(1, 3);
@@ -61,7 +67,7 @@ public:
             
             // Explicitly clear casting emotes and set to combat stance
             me->HandleEmoteCommand(EMOTE_ONESHOT_NONE);
-            me->Say("DEBUG: Emotes cleared for combat!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: Emotes cleared for combat!");
             me->SetStandState(UNIT_STAND_STATE_STAND);
             
             events.ScheduleEvent(EVENT_SHADOW_BOLT, urand(2000, 4000));
@@ -74,7 +80,7 @@ public:
             
             // Clear emotes first, then set casting emote with delay for proper transition
             me->HandleEmoteCommand(EMOTE_ONESHOT_NONE);
-            me->Say("DEBUG: Evade mode - emotes cleared, will resume casting!", LANG_UNIVERSAL);
+            KR_DEBUG_SAY("DEBUG: Evade mode - emotes cleared, will resume casting!");
             
             // Delay the casting emote to avoid conflicts
             events.ScheduleEvent(EVENT_DARK_ENERGY_CAST, 2000); // Longer delay for stable transition
@@ -91,7 +97,7 @@ public:
                     
                     // Use Trial of Crusader style spell precast emote (more reliable)
                     me->HandleEmoteCommand(EMOTE_STATE_SPELL_PRECAST);
-                    me->Say("DEBUG: Cast emote set - should see casting animation!", LANG_UNIVERSAL);
+                    KR_DEBUG_SAY("DEBUG: Cast emote set - should see casting animation!");
                     
                     // Cast visual dark energy spell
                     DoCast(polydeuces, SPELL_DARK_ENERGY_VISUAL, true);


### PR DESCRIPTION
## Summary
- Wrap Polydeuces boss debug text with `KR_DEBUG_*` macros
- Wrap Hexenmeister NPC debug text behind DEBUG guard

## Testing
- `g++ -c src/boss_polydeuces.cpp` *(fails: CreatureScript.h: No such file or directory)*
- `g++ -c src/npc_hexenmeister.cpp` *(fails: CreatureScript.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac67ae4d588323890507c39323abbd