### PR TITLE
Remove debug messages from scripts

### DIFF
--- a/src/npc_dione.cpp
+++ b/src/npc_dione.cpp
@@ -31,8 +31,6 @@ public:
             events.ScheduleEvent(EVENT_DIONE_FROSTBOLT1, urand(2000, 4000));  // Quicker first cast
             events.ScheduleEvent(EVENT_DIONE_FROSTBOLT2, urand(8000, 12000)); // Earlier strong attack
             
-            // Debug message
-            me->Say("Dione joins the battle!", LANG_UNIVERSAL);
         }
 
         void UpdateAI(uint32 diff) override

--- a/src/npc_hexenmeister.cpp
+++ b/src/npc_hexenmeister.cpp
@@ -19,14 +19,11 @@ public:
 
         void Reset() override
         {
-            // ULTIMATE DEBUG - Test if Hexenmeister script runs
-            me->Say("ULTIMATE DEBUG: Hexenmeister Reset() called!", LANG_UNIVERSAL);
             
             events.Reset();
             
             // Clear any existing emotes before setting new ones
             me->HandleEmoteCommand(EMOTE_ONESHOT_NONE);
-            me->Say("DEBUG: Emotes cleared on Reset!", LANG_UNIVERSAL);
             
             CastDarkEnergyOnPolydeuces();
             // Start continuous dark energy casting
@@ -35,8 +32,6 @@ public:
         
         void JustEngagedWith(Unit* /*who*/) override
         {
-            // ULTIMATE DEBUG - Test if combat works
-            me->Say("ULTIMATE DEBUG: Hexenmeister Combat started!", LANG_UNIVERSAL);
             
             // Random modern C++ string yell
             uint8 randomYell = urand(1, 3);
@@ -61,7 +56,6 @@ public:
             
             // Explicitly clear casting emotes and set to combat stance
             me->HandleEmoteCommand(EMOTE_ONESHOT_NONE);
-            me->Say("DEBUG: Emotes cleared for combat!", LANG_UNIVERSAL);
             me->SetStandState(UNIT_STAND_STATE_STAND);
             
             events.ScheduleEvent(EVENT_SHADOW_BOLT, urand(2000, 4000));
@@ -74,7 +68,6 @@ public:
             
             // Clear emotes first, then set casting emote with delay for proper transition
             me->HandleEmoteCommand(EMOTE_ONESHOT_NONE);
-            me->Say("DEBUG: Evade mode - emotes cleared, will resume casting!", LANG_UNIVERSAL);
             
             // Delay the casting emote to avoid conflicts
             events.ScheduleEvent(EVENT_DARK_ENERGY_CAST, 2000); // Longer delay for stable transition
@@ -91,7 +84,6 @@ public:
                     
                     // Use Trial of Crusader style spell precast emote (more reliable)
                     me->HandleEmoteCommand(EMOTE_STATE_SPELL_PRECAST);
-                    me->Say("DEBUG: Cast emote set - should see casting animation!", LANG_UNIVERSAL);
                     
                     // Cast visual dark energy spell
                     DoCast(polydeuces, SPELL_DARK_ENERGY_VISUAL, true);

--- a/src/npc_hexenmeister.cpp
+++ b/src/npc_hexenmeister.cpp
@@ -5,6 +5,14 @@
 
 #include "kaykens_reminiszenz.h"
 
+#ifdef DEBUG
+#define KR_DEBUG_SAY(me, text) do { (me)->Say(text, LANG_UNIVERSAL); } while (0)
+#define KR_DEBUG_YELL(me, text) do { (me)->Yell(text, LANG_UNIVERSAL); } while (0)
+#else
+#define KR_DEBUG_SAY(me, text) do {} while (0)
+#define KR_DEBUG_YELL(me, text) do {} while (0)
+#endif
+
 class npc_hexenmeister : public CreatureScript
 {
 public:
@@ -19,11 +27,14 @@ public:
 
         void Reset() override
         {
+            // ULTIMATE DEBUG - Test if Hexenmeister script runs
+            KR_DEBUG_SAY(me, "ULTIMATE DEBUG: Hexenmeister Reset() called!");
             
             events.Reset();
             
             // Clear any existing emotes before setting new ones
             me->HandleEmoteCommand(EMOTE_ONESHOT_NONE);
+            KR_DEBUG_SAY(me, "DEBUG: Emotes cleared on Reset!");
             
             CastDarkEnergyOnPolydeuces();
             // Start continuous dark energy casting
@@ -32,6 +43,8 @@ public:
         
         void JustEngagedWith(Unit* /*who*/) override
         {
+            // ULTIMATE DEBUG - Test if combat works
+            KR_DEBUG_SAY(me, "ULTIMATE DEBUG: Hexenmeister Combat started!");
             
             // Random modern C++ string yell
             uint8 randomYell = urand(1, 3);
@@ -56,6 +69,7 @@ public:
             
             // Explicitly clear casting emotes and set to combat stance
             me->HandleEmoteCommand(EMOTE_ONESHOT_NONE);
+            KR_DEBUG_SAY(me, "DEBUG: Emotes cleared for combat!");
             me->SetStandState(UNIT_STAND_STATE_STAND);
             
             events.ScheduleEvent(EVENT_SHADOW_BOLT, urand(2000, 4000));
@@ -68,6 +82,7 @@ public:
             
             // Clear emotes first, then set casting emote with delay for proper transition
             me->HandleEmoteCommand(EMOTE_ONESHOT_NONE);
+            KR_DEBUG_SAY(me, "DEBUG: Evade mode - emotes cleared, will resume casting!");
             
             // Delay the casting emote to avoid conflicts
             events.ScheduleEvent(EVENT_DARK_ENERGY_CAST, 2000); // Longer delay for stable transition
@@ -84,6 +99,7 @@ public:
                     
                     // Use Trial of Crusader style spell precast emote (more reliable)
                     me->HandleEmoteCommand(EMOTE_STATE_SPELL_PRECAST);
+                    KR_DEBUG_SAY(me, "DEBUG: Cast emote set - should see casting animation!");
                     
                     // Cast visual dark energy spell
                     DoCast(polydeuces, SPELL_DARK_ENERGY_VISUAL, true);


### PR DESCRIPTION
## Summary
- Strip debug output from Polydeuces boss script
- Remove debug text from Hexenmeister NPC
- Delete debug say from Dione NPC

## Testing
- `g++ -c src/boss_polydeuces.cpp` *(fails: CreatureScript.h: No such file or directory)*
- `g++ -c src/npc_hexenmeister.cpp` *(fails: CreatureScript.h: No such file or directory)*
- `g++ -c src/npc_dione.cpp` *(fails: CreatureScript.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac67ae4d588323890507c39323abbd